### PR TITLE
Issue #2 - too big images in small galleries

### DIFF
--- a/js/pycs-layout.jquery.js
+++ b/js/pycs-layout.jquery.js
@@ -135,6 +135,10 @@
 	totalWidth += (parseInt($(items[i]).attr("data-pycs-vwidth")) +
 		       settings.gutter);
       }
+		
+	  if (totalWidth < containerWidth) {
+		return [[...items]];
+	  }
       rows_number = Math.round(totalWidth / containerWidth);
 
       /* all the elements on the same row. */


### PR DESCRIPTION
When the number of images is so small that they cannot even fill a single line in the gallery div, then they are scaled up to the width of the container anyway. This produces unwanted behavior that creates big images (e.g. on the entire screen) when we don't know how many images will be in the gallery beforehand. 

See issue #2 for details on how to reproduce this issue.